### PR TITLE
Add electron-prebuilt to dev dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,15 @@ prior to submitting an issue or pull request
 
 ### Setup
 
-1. First, you must create an app in Dropbox.
+1. First, you must
+   [create an app](https://www.dropbox.com/developers/apps/create) in Dropbox.
 2. Copy `config.sample.js` to `config.js`, and add your Dropbox app key to the
    config.
-3. Install Electron: `npm install -g electron-prebuilt`
+3. Install dependencies: `npm install`
 
 ### Running
 
-`electron DropCap`
+`npm start`
 
 ### Building for Release
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Sync screen captures with Dropbox",
   "main": "main.js",
   "scripts": {
+    "start": "electron .",
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "/bin/bash ./bin/icon && /usr/bin/env node ./bin/build.js"
   },
@@ -20,6 +21,7 @@
     "snabbdom": "^0.2.1"
   },
   "devDependencies": {
-    "electron-packager": "^5.0.1"
+    "electron-packager": "^5.0.1",
+    "electron-prebuilt": "^0.30.2"
   }
 }


### PR DESCRIPTION
Breaking changes have been made to the Electron's API that causes DropCap to throw an error on startup if the latest version is installed using `npm install -g electron-prebuilt`.

Adding electron-prebuilt to the devDependencies will allow the required version to be managed.
